### PR TITLE
multi project handling

### DIFF
--- a/lib/tabcontrol.js
+++ b/lib/tabcontrol.js
@@ -51,7 +51,9 @@ export class TabControl {
           {
             console.log("Stashing:", path);
             newStash.push(path);
-            editor.destroy();
+            if(editor.getPath().search(repo.getPath().replace('/\.git/',''))) {
+               editor.destroy();
+            }
             if(!didWork)
             {
               atom.notifications.addInfo("Git-Tab-Manager: Updating tabs");


### PR DESCRIPTION
Hi, I have added a further check which makes this plugin capable of handling multiple projects in the same window.
As far as I have tested, is able to close only tabs related to the selected repo, leaving others untouched.

I hope you'll find it interesting and fully working.